### PR TITLE
Use clearer module IDs to disambiguate between JS / HTML entrypoints

### DIFF
--- a/spec/chatgpt-widgets.spec.ts
+++ b/spec/chatgpt-widgets.spec.ts
@@ -16,12 +16,12 @@ describe("vite-plugin-chatgpt-widgets", () => {
       expect(html).toContain('<meta charset="UTF-8" />');
       expect(html).toContain("<title>TestWidget Widget</title>");
       expect(html).toContain('<div id="root"></div>');
-      expect(html).toContain('<script type="module" src="virtual:chatgpt-widget-TestWidget.js"></script>');
+      expect(html).toContain('<script type="module" src="virtual:chatgpt-widget-entrypoint-TestWidget.js"></script>');
     });
 
     it("should use virtual: protocol for the script src", () => {
       const html = generateWidgetEntrypointHTML("MyWidget");
-      expect(html).toContain('src="virtual:chatgpt-widget-MyWidget.js"');
+      expect(html).toContain('src="virtual:chatgpt-widget-entrypoint-MyWidget.js"');
     });
 
     it("should properly escape widget names in titles", () => {
@@ -34,15 +34,15 @@ describe("vite-plugin-chatgpt-widgets", () => {
     it("should resolve virtual HTML entrypoints", () => {
       const plugin = chatGPTWidgetPlugin();
 
-      const result = (plugin as any).resolveId("virtual:chatgpt-widget-Test.html");
-      expect(result).toBe("virtual:chatgpt-widget-Test.html");
+      const result = (plugin as any).resolveId("virtual:chatgpt-widget-html-Test.html");
+      expect(result).toBe("virtual:chatgpt-widget-html-Test.html");
     });
 
     it("should resolve virtual JS entrypoints with null byte prefix", () => {
       const plugin = chatGPTWidgetPlugin();
 
-      const result = (plugin as any).resolveId("virtual:chatgpt-widget-Test.js");
-      expect(result).toBe("\0virtual:chatgpt-widget-Test.js");
+      const result = (plugin as any).resolveId("virtual:chatgpt-widget-entrypoint-Test.js");
+      expect(result).toBe("\0virtual:chatgpt-widget-entrypoint-Test.js");
     });
 
     it("should return null for non-virtual modules", () => {
@@ -56,8 +56,8 @@ describe("vite-plugin-chatgpt-widgets", () => {
       const plugin = chatGPTWidgetPlugin();
 
       expect((plugin as any).resolveId("virtual:chatgpt-widget")).toBeNull();
-      expect((plugin as any).resolveId("chatgpt-widget-Test.html")).toBeNull();
-      expect((plugin as any).resolveId("virtual:chatgpt-widget-Test.css")).toBeNull();
+      expect((plugin as any).resolveId("chatgpt-widget-html-Test.html")).toBeNull();
+      expect((plugin as any).resolveId("virtual:chatgpt-widget-entrypoint-Test.css")).toBeNull();
     });
   });
 
@@ -65,7 +65,7 @@ describe("vite-plugin-chatgpt-widgets", () => {
     it("should load virtual HTML files using generateWidgetEntrypointHTML", async () => {
       const plugin = chatGPTWidgetPlugin();
 
-      const result = await (plugin as any).load("virtual:chatgpt-widget-TestWidget.html");
+      const result = await (plugin as any).load("virtual:chatgpt-widget-html-TestWidget.html");
 
       // Should use the same HTML generation function
       const expected = generateWidgetEntrypointHTML("TestWidget");
@@ -83,7 +83,7 @@ describe("vite-plugin-chatgpt-widgets", () => {
       const plugin = chatGPTWidgetPlugin();
 
       expect(await (plugin as any).load("virtual:other-module")).toBeNull();
-      expect(await (plugin as any).load("virtual:chatgpt-widget-Test.css")).toBeNull();
+      expect(await (plugin as any).load("virtual:chatgpt-widget-entrypoint-Test.js")).toBeNull();
     });
   });
 

--- a/spec/integration/basic-project.spec.ts
+++ b/spec/integration/basic-project.spec.ts
@@ -46,7 +46,7 @@ describe("Basic Project Integration", () => {
 
       // Check that the script tag is present and uses absolute URL
       expect(html).toContain('<script type="module"');
-      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-TestWidget.js");
+      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-TestWidget.js");
     });
 
     it("should generate different HTML for different widgets in dev mode", async () => {
@@ -56,8 +56,8 @@ describe("Basic Project Integration", () => {
       expect(testWidgetHtml).toContain("TestWidget Widget");
       expect(anotherWidgetHtml).toContain("AnotherWidget Widget");
 
-      expect(testWidgetHtml).toContain("/@id/virtual:chatgpt-widget-TestWidget.js");
-      expect(anotherWidgetHtml).toContain("/@id/virtual:chatgpt-widget-AnotherWidget.js");
+      expect(testWidgetHtml).toContain("/@id/virtual:chatgpt-widget-entrypoint-TestWidget.js");
+      expect(anotherWidgetHtml).toContain("/@id/virtual:chatgpt-widget-entrypoint-AnotherWidget.js");
     });
 
     it("should generate HTML even for non-existent widgets in dev mode", async () => {
@@ -65,7 +65,7 @@ describe("Basic Project Integration", () => {
       // The error only occurs when the JS module is loaded by the browser
       const { content: html } = await getWidgetHTML("NonExistentWidget", { devServer });
       expect(html).toContain("NonExistentWidget Widget");
-      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-NonExistentWidget.js");
+      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-NonExistentWidget.js");
     });
 
     it("should include all widgets in getWidgets result with content", async () => {
@@ -76,7 +76,7 @@ describe("Basic Project Integration", () => {
         expect(widget.filePath).toBeTruthy();
         expect(widget.content).toContain("<!DOCTYPE html>");
         expect(widget.content).toContain(`<title>${widget.name} Widget</title>`);
-        expect(widget.content).toContain("https://example.com/@id/virtual:chatgpt-widget-");
+        expect(widget.content).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-");
       }
     });
 
@@ -84,7 +84,7 @@ describe("Basic Project Integration", () => {
       const { content: html } = await getWidgetHTML("TestWidget", { devServer });
 
       // Extract the JavaScript module URL from the HTML
-      const scriptMatch = html.match(/src="([^"]+virtual:chatgpt-widget-TestWidget\.js[^"]*)"/);
+      const scriptMatch = html.match(/src="([^"]+virtual:chatgpt-widget-entrypoint-TestWidget\.js[^"]*)"/);
       expect(scriptMatch).toBeTruthy();
 
       const scriptUrl = scriptMatch![1].replace("https://example.com/@id/", "").replace("https://example.com/", "");
@@ -162,12 +162,12 @@ describe("Basic Project Integration", () => {
       const manifestContent = await fs.readFile(MANIFEST_PATH, "utf-8");
       const manifest = JSON.parse(manifestContent);
 
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-TestWidget.html");
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-AnotherWidget.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-TestWidget.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-AnotherWidget.html");
 
       // Verify the manifest entries point to actual files
-      expect(manifest["virtual:chatgpt-widget-TestWidget.html"].file).toBeTruthy();
-      expect(manifest["virtual:chatgpt-widget-AnotherWidget.html"].file).toBeTruthy();
+      expect(manifest["virtual:chatgpt-widget-html-TestWidget.html"].file).toBeTruthy();
+      expect(manifest["virtual:chatgpt-widget-html-AnotherWidget.html"].file).toBeTruthy();
     });
 
     it("should discover widgets in production mode", async () => {

--- a/spec/integration/plain-react.spec.ts
+++ b/spec/integration/plain-react.spec.ts
@@ -40,7 +40,7 @@ describe("Plain React (without React Router)", () => {
       expect(html).toContain("<title>CounterWidget Widget</title>");
       expect(html).toContain('<div id="root"></div>');
       expect(html).toContain('<script type="module"');
-      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-CounterWidget.js");
+      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-CounterWidget.js");
     });
 
     it("should generate HTML for both plain React widgets", async () => {
@@ -50,8 +50,8 @@ describe("Plain React (without React Router)", () => {
       expect(counterHtml).toContain("CounterWidget Widget");
       expect(greetingHtml).toContain("GreetingWidget Widget");
 
-      expect(counterHtml).toContain("/@id/virtual:chatgpt-widget-CounterWidget.js");
-      expect(greetingHtml).toContain("/@id/virtual:chatgpt-widget-GreetingWidget.js");
+      expect(counterHtml).toContain("/@id/virtual:chatgpt-widget-entrypoint-CounterWidget.js");
+      expect(greetingHtml).toContain("/@id/virtual:chatgpt-widget-entrypoint-GreetingWidget.js");
     });
 
     it("should include all plain React widgets in getWidgets result", async () => {
@@ -62,7 +62,7 @@ describe("Plain React (without React Router)", () => {
         expect(widget.filePath).toBeTruthy();
         expect(widget.content).toContain("<!DOCTYPE html>");
         expect(widget.content).toContain(`<title>${widget.name} Widget</title>`);
-        expect(widget.content).toContain("https://example.com/@id/virtual:chatgpt-widget-");
+        expect(widget.content).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-");
       }
     });
 
@@ -120,11 +120,11 @@ describe("Plain React (without React Router)", () => {
       const manifestContent = await fs.readFile(MANIFEST_PLAIN_REACT_PATH, "utf-8");
       const manifest = JSON.parse(manifestContent);
 
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-CounterWidget.html");
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-GreetingWidget.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-CounterWidget.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-GreetingWidget.html");
 
-      expect(manifest["virtual:chatgpt-widget-CounterWidget.html"].file).toBeTruthy();
-      expect(manifest["virtual:chatgpt-widget-GreetingWidget.html"].file).toBeTruthy();
+      expect(manifest["virtual:chatgpt-widget-html-CounterWidget.html"].file).toBeTruthy();
+      expect(manifest["virtual:chatgpt-widget-html-GreetingWidget.html"].file).toBeTruthy();
     });
 
     it("should discover plain React widgets in production mode", async () => {
@@ -152,7 +152,7 @@ describe("Plain React (without React Router)", () => {
       const manifestContent = await fs.readFile(MANIFEST_PLAIN_REACT_PATH, "utf-8");
       const manifest = JSON.parse(manifestContent);
 
-      const widgetEntries = Object.entries(manifest).filter(([key]) => key.startsWith("virtual:chatgpt-widget-"));
+      const widgetEntries = Object.entries(manifest).filter(([key]) => key.startsWith("virtual:chatgpt-widget-html-"));
 
       for (const [, entry] of widgetEntries) {
         const filePath = path.join(BUILD_PLAIN_REACT_DIR, (entry as any).file);

--- a/spec/integration/react-router.spec.ts
+++ b/spec/integration/react-router.spec.ts
@@ -41,7 +41,7 @@ describe("React Router v7 Integration", () => {
       expect(html).toContain("<title>NavigationWidget Widget</title>");
       expect(html).toContain('<div id="root"></div>');
       expect(html).toContain('<script type="module"');
-      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-NavigationWidget.js");
+      expect(html).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-NavigationWidget.js");
     });
 
     it("should generate HTML for both React Router widgets", async () => {
@@ -51,8 +51,8 @@ describe("React Router v7 Integration", () => {
       expect(navWidgetHtml).toContain("NavigationWidget Widget");
       expect(dataWidgetHtml).toContain("DataWidget Widget");
 
-      expect(navWidgetHtml).toContain("/@id/virtual:chatgpt-widget-NavigationWidget.js");
-      expect(dataWidgetHtml).toContain("/@id/virtual:chatgpt-widget-DataWidget.js");
+      expect(navWidgetHtml).toContain("/@id/virtual:chatgpt-widget-entrypoint-NavigationWidget.js");
+      expect(dataWidgetHtml).toContain("/@id/virtual:chatgpt-widget-entrypoint-DataWidget.js");
     });
 
     it("should include all React Router widgets in getWidgets result", async () => {
@@ -63,7 +63,7 @@ describe("React Router v7 Integration", () => {
         expect(widget.filePath).toBeTruthy();
         expect(widget.content).toContain("<!DOCTYPE html>");
         expect(widget.content).toContain(`<title>${widget.name} Widget</title>`);
-        expect(widget.content).toContain("https://example.com/@id/virtual:chatgpt-widget-");
+        expect(widget.content).toContain("https://example.com/@id/virtual:chatgpt-widget-entrypoint-");
       }
     });
 
@@ -128,11 +128,11 @@ describe("React Router v7 Integration", () => {
       const manifestContent = await fs.readFile(MANIFEST_REACT_ROUTER_PATH, "utf-8");
       const manifest = JSON.parse(manifestContent);
 
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-NavigationWidget.html");
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-DataWidget.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-NavigationWidget.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-DataWidget.html");
 
-      expect(manifest["virtual:chatgpt-widget-NavigationWidget.html"].file).toBeTruthy();
-      expect(manifest["virtual:chatgpt-widget-DataWidget.html"].file).toBeTruthy();
+      expect(manifest["virtual:chatgpt-widget-html-NavigationWidget.html"].file).toBeTruthy();
+      expect(manifest["virtual:chatgpt-widget-html-DataWidget.html"].file).toBeTruthy();
     });
 
     it("should discover React Router widgets in production mode", async () => {
@@ -320,7 +320,7 @@ describe("React Router v7 Integration", () => {
       const { content: devHtml } = await getWidgetHTML("SimpleWidget", { devServer });
 
       // Extract the script src
-      const scriptMatch = devHtml.match(/src="([^"]+virtual:chatgpt-widget-SimpleWidget\.js[^"]*)"/);
+      const scriptMatch = devHtml.match(/src="([^"]+virtual:chatgpt-widget-entrypoint-SimpleWidget\.js[^"]*)"/);
       expect(scriptMatch).toBeTruthy();
 
       // Fetch the JavaScript module from the dev server to verify it contains the React Router HMR runtime

--- a/spec/integration/root-layout.spec.ts
+++ b/spec/integration/root-layout.spec.ts
@@ -71,10 +71,10 @@ describe("Root Layout Component", () => {
       const manifestContent = await fs.readFile(MANIFEST_WITH_ROOT_PATH, "utf-8");
       const manifest = JSON.parse(manifestContent);
 
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-WidgetA.html");
-      expect(manifest).toHaveProperty("virtual:chatgpt-widget-WidgetB.html");
-      expect(manifest).not.toHaveProperty("virtual:chatgpt-widget-root.html");
-      expect(manifest).not.toHaveProperty("virtual:chatgpt-widget-Root.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-WidgetA.html");
+      expect(manifest).toHaveProperty("virtual:chatgpt-widget-html-WidgetB.html");
+      expect(manifest).not.toHaveProperty("virtual:chatgpt-widget-html-root.html");
+      expect(manifest).not.toHaveProperty("virtual:chatgpt-widget-html-Root.html");
     });
 
     it("should discover widgets excluding root in production mode", async () => {


### PR DESCRIPTION
so its less confusing which module is which