### PR TITLE
Re order module load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-chatgpt-widgets",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "files": [
     "Readme.md",
     "dist/**/*"

--- a/spec/fixtures/test-project-with-root/web/chatgpt/WidgetA.tsx
+++ b/spec/fixtures/test-project-with-root/web/chatgpt/WidgetA.tsx
@@ -1,3 +1,5 @@
+import "./widget.css";
+
 export default function WidgetA() {
   return (
     <div className="widget-a">

--- a/spec/fixtures/test-project-with-root/web/chatgpt/root.css
+++ b/spec/fixtures/test-project-with-root/web/chatgpt/root.css
@@ -1,0 +1,23 @@
+/* Root layout styles - should be loaded first */
+.root-layout {
+  font-family: system-ui, sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.root-header {
+  background-color: #f0f0f0;
+  padding: 1rem;
+}
+
+.root-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.root-footer {
+  background-color: #f0f0f0;
+  padding: 1rem;
+}
+

--- a/spec/fixtures/test-project-with-root/web/chatgpt/root.tsx
+++ b/spec/fixtures/test-project-with-root/web/chatgpt/root.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "./root.css";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/spec/fixtures/test-project-with-root/web/chatgpt/widget.css
+++ b/spec/fixtures/test-project-with-root/web/chatgpt/widget.css
@@ -1,0 +1,16 @@
+/* Widget styles - should be loaded after root styles */
+.widget-a {
+  background-color: #e0e0ff;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.widget-a h2 {
+  color: #333;
+  margin-bottom: 0.5rem;
+}
+
+.widget-a p {
+  color: #666;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -437,8 +437,8 @@ export function chatGPTWidgetPlugin(options: ChatGPTWidgetPluginOptions = {}): C
           return `
 ${hmrRuntimeSetup}import React from 'react';
 import { createRoot } from 'react-dom/client';
-import Widget from '${widgetFile}';
 import RootLayout from '${rootFile}';
+import Widget from '${widgetFile}';
 
 const container = document.getElementById('root');
 if (!container) {


### PR DESCRIPTION
In trying to set up the css in https://github.com/openai/apps-sdk-ui I found that it is very important that the package's css (and the tailwind layout orders) load before any component imported css

adding the css import to the top of a gadget `root.tsx` was not providing this order and it turns out it was because in our virtual widget module we were loading the Widget module before we were loading the root module :(

this PR resolves that