### PR TITLE
Add @openai/apps-sdk-ui packages to optimizeDeps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -312,6 +312,7 @@ export function chatGPTWidgetPlugin(options: ChatGPTWidgetPluginOptions = {}): C
       return {
         optimizeDeps: {
           include: hasGadgetPackage ? [gadgetPackage] : [],
+          entries: `${widgetsDir}/**/*.{jsx,tsx}`,
         },
       };
     },


### PR DESCRIPTION
Previously, the plugin only conditionally included the Gadget package in Vite's `optimizeDeps.include` configuration, which meant that projects using the `@openai/apps-sdk-ui` package would fail to load on the first page visit during development, requiring users to manually refresh the page before the widgets would work.

This PR adds an `optimizeDeps.entries` configuration that tells Vite to scan all widget files (`${widgetsDir}/**/*.{jsx,tsx}`) as entry points for dependency optimisation. This ensures that any dependencies imported by widget components—including UI libraries like the Gadget package or OpenAI Apps SDK UI components—are automatically discovered and pre-bundled by Vite, allowing widgets to load correctly on the first visit without requiring a page refresh.